### PR TITLE
switch to using Naersk for package builds

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,9 +1,7 @@
 { sources ? import ./nix/sources.nix { }, pkgs ? import sources.nixpkgs { }
 , cargoSha256 ? "RSvkJhXS4neUaNVaHPRjEGqW2/pb51FbNtCoX2a4ePs=", ... }:
 with pkgs;
-let
-  sources = import ./nix/sources.nix;
-  gitignore = import sources.gitignore { };
+let gitignore = pkgs.callPackage sources.gitignore { };
 in rustPlatform.buildRustPackage rec {
   pname = "firstaide";
   version = "0.1.6";

--- a/default.nix
+++ b/default.nix
@@ -1,23 +1,11 @@
-{ sources ? import ./nix/sources.nix { }, pkgs ? import sources.nixpkgs { }
-, cargoSha256 ? "RSvkJhXS4neUaNVaHPRjEGqW2/pb51FbNtCoX2a4ePs=", ... }:
+{ sources ? import ./nix/sources.nix { }, pkgs ? import sources.nixpkgs { }, ...
+}:
 with pkgs;
-let gitignore = pkgs.callPackage sources.gitignore { };
-in rustPlatform.buildRustPackage rec {
-  pname = "firstaide";
-  version = "0.1.6";
+let
+  gitignore = pkgs.callPackage sources.gitignore { };
+  naersk = pkgs.callPackage sources.naersk { };
+in naersk.buildPackage {
   src = gitignore.gitignoreSource ./.;
-
-  # The crypto_hash crate needs the openssl-sys crate (directly or indirectly,
-  # I don't know) which ultimately needs openssl proper, and pkg-config.
-  buildInputs = [ openssl pkg-config ];
-
-  # Don't run tests when building.
-  doCheck = false;
-
-  # I think this refers to the current state of the crates.io repo. To update,
-  # replace the hash with all 0's and Nix will give you the right value to
-  # stick in here.
-  inherit cargoSha256;
 
   meta = with pkgs.lib; {
     description = "Bootstrap Nix environments.";

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -11,6 +11,18 @@
         "url": "https://github.com/hercules-ci/gitignore/archive/c4662e662462e7bf3c2a968483478a665d00e717.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
+    "naersk": {
+        "branch": "master",
+        "description": "Build rust crates in Nix. No configuration, no code generation, no IFD. Sandbox friendly. [maintainer: ???]",
+        "homepage": "",
+        "owner": "nix-community",
+        "repo": "naersk",
+        "rev": "2fc8ce9d3c025d59fee349c1f80be9785049d653",
+        "sha256": "1jhagazh69w7jfbrchhdss54salxc66ap1a1yd7xasc92vr0qsx4",
+        "type": "tarball",
+        "url": "https://github.com/nix-community/naersk/archive/2fc8ce9d3c025d59fee349c1f80be9785049d653.tar.gz",
+        "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
+    },
     "niv": {
         "branch": "master",
         "description": "Easy dependency management for Nix projects",


### PR DESCRIPTION
This lets us avoid having to specify `cargoSha256` in the build config. Long run that should make dependabot updates easier since we won't have a manual step of updating the that value.

As some bonuses, Naersk...

- reads the package name and version from `Cargo.toml`, so that won't get out of sync either.
- builds the crate dependencies separately from the binary, making incremental rebuilds faster.
