### PR TITLE
use GitHub Actions for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+
+jobs:
+  build-and-test:
+    name: build and test
+    strategy:
+      matrix:
+        # note: we're using ubuntu-latest as a stand-in for all Linux
+        # distributions. If we find we need more, we should do Docker stuff.
+        os: [ubuntu-latest, macos-11]
+    runs-on: "${{ matrix.os }}"
+    steps:
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v16
+
+      - run: nix-build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,0 @@
-language: rust

--- a/default.nix
+++ b/default.nix
@@ -7,6 +7,9 @@ let
 in naersk.buildPackage {
   src = gitignore.gitignoreSource ./.;
 
+  doCheck = true;
+  checkPhase = "cargo test";
+
   meta = with pkgs.lib; {
     description = "Bootstrap Nix environments.";
     homepage = "https://github.com/allenap/firstaide";

--- a/default.nix
+++ b/default.nix
@@ -7,6 +7,8 @@ let
 in naersk.buildPackage {
   src = gitignore.gitignoreSource ./.;
 
+  buildInputs = [ pkgs.openssl pkgs.pkg-config ];
+
   doCheck = true;
   checkPhase = "cargo test";
 


### PR DESCRIPTION
our Travis integration is just doing the naive Rust thing and skipping everything in Nix, so we weren't getting build errors there. Rather than figure out how to do it in Travis, I'm just using the Nix/Rust configuration I use in some other projects with GitHub actions.

This shouldn't affect our budget, as GitHub actions has an unlimited amount of minutes for open-source projects. We're already using it on noredink-ui and it's fine.
