### PR TITLE
make hooks messages configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,18 @@ eval "$(firstaide hook)"
 
 Then run `firstaide build` (or `firstaide --help`).
 
+### Messages
+
+the `messages` section of `.firstaide.toml` allows you to configure the help text shown by direnv when the environment is inactive, stale, and loaded
+
+by default the messages are set as follows:
+
+```toml
+[messages]
+getting_started = "firstaide --help" # displayed when direnv loads successfully
+stale = "firstaide build"
+inactive = "build firstaide and run \"firstaide build\""
+```
 
 ## To develop:
 

--- a/src/cmds/hook.rs
+++ b/src/cmds/hook.rs
@@ -91,18 +91,18 @@ impl Command {
                 );
                 env_diff.simplify();
                 if sums::equal(&sums_now, &cache.sums) {
-                    let chunk_message = bash::escape(&config.messages.getting_started);
-                    let chunk_content =
-                        include_bytes!("hook/active.sh").replace(b"__MESSAGE__", chunk_message);
+                    let getting_started_message = bash::escape(&config.messages.getting_started);
+                    let chunk_content = include_bytes!("hook/active.sh")
+                        .replace(b"__MESSAGE__", getting_started_message);
                     handle
                         .write_all(&chunk(&EnvironmentStatus::Okay.display(), &chunk_content))
                         .context("could not write active hook")?;
                 } else {
+                    let stale_message = bash::escape(&config.messages.stale);
+                    let chunk_content =
+                        include_bytes!("hook/stale.sh").replace(b"__MESSAGE__", stale_message);
                     handle
-                        .write_all(&chunk(
-                            &EnvironmentStatus::Stale.display(),
-                            include_bytes!("hook/stale.sh"),
-                        ))
+                        .write_all(&chunk(&EnvironmentStatus::Stale.display(), &chunk_content))
                         .context("could not write stale hook")?;
                 }
                 handle
@@ -137,10 +137,13 @@ impl Command {
                 }
             }
             Err(_) => {
+                let inactive_message = bash::escape(&config.messages.inactive);
+                let chunk_content =
+                    include_bytes!("hook/stale.sh").replace(b"__MESSAGE__", inactive_message);
                 handle
                     .write_all(&chunk(
                         &EnvironmentStatus::Unknown.display(),
-                        include_bytes!("hook/inactive.sh"),
+                        &chunk_content,
                     ))
                     .context("could not write inactive hook")?;
                 handle

--- a/src/cmds/hook.rs
+++ b/src/cmds/hook.rs
@@ -139,7 +139,7 @@ impl Command {
             Err(_) => {
                 let inactive_message = bash::escape(&config.messages.inactive);
                 let chunk_content =
-                    include_bytes!("hook/stale.sh").replace(b"__MESSAGE__", inactive_message);
+                    include_bytes!("hook/inactive.sh").replace(b"__MESSAGE__", inactive_message);
                 handle
                     .write_all(&chunk(
                         &EnvironmentStatus::Unknown.display(),

--- a/src/cmds/hook/inactive.sh
+++ b/src/cmds/hook/inactive.sh
@@ -1,3 +1,4 @@
 # shellcheck shell=bash
 log_status "$(error ERROR): $(em 'Nix environment is not yet built!')" >&2
-log_status "--> Use $(em ./bootstrap) to build it." >&2
+log_status "--> Use $(em __MESSAGE__) to build it." >&2
+log_status "        $(m=__MESSAGE__ && em "${m//?/^}")" >&2

--- a/src/cmds/hook/stale.sh
+++ b/src/cmds/hook/stale.sh
@@ -1,4 +1,5 @@
 # shellcheck shell=bash
 log_status "$(warning WARNING): $(em 'Nix environment is out of date!') " >&2
-log_status "--> Use $(em firstaide-update) to rebuild it." >&2
+log_status "--> Use $(em __MESSAGE__) to rebuild it." >&2
+log_status "        $(m=__MESSAGE__ && em "${m//?/^}")" >&2
 log_status "$(warning WARNING): Loading $(em STALE) environment ;-(" >&2

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,12 +52,16 @@ impl AsRef<Path> for ParentDir {
 #[derive(Debug, Deserialize)]
 pub struct Messages {
     pub getting_started: String,
+    pub stale: String,
+    pub inactive: String,
 }
 
 impl Default for Messages {
     fn default() -> Self {
         Self {
-            getting_started: "aide --help".into(),
+            getting_started: "firstaide --help".into(),
+            stale: "firstaide build".into(),
+            inactive: "build firstaide and run \"firstaide build\"".into(),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,19 +51,31 @@ impl AsRef<Path> for ParentDir {
 
 #[derive(Debug, Deserialize)]
 pub struct Messages {
+    #[serde(default = "default_getting_started")]
     pub getting_started: String,
+    #[serde(default = "default_stale")]
     pub stale: String,
+    #[serde(default = "default_inactive")]
     pub inactive: String,
 }
-
 impl Default for Messages {
     fn default() -> Self {
         Self {
-            getting_started: "firstaide --help".into(),
-            stale: "firstaide build".into(),
-            inactive: "build firstaide and run \"firstaide build\"".into(),
+            getting_started: default_getting_started(),
+            stale: default_stale(),
+            inactive: default_inactive(),
         }
     }
+}
+
+fn default_getting_started() -> String {
+    "firstaide --help".to_string()
+}
+fn default_stale() -> String {
+    "firstaide build".to_string()
+}
+fn default_inactive() -> String {
+    "build firstaide and run \"firstaide build\"".to_string()
 }
 
 impl Config {


### PR DESCRIPTION
...and update them to reflect current usage

why:
- these messages appeared to be just wrong (referencing `aide` instead of firstaide or an `update` command that doesn't appear to exist)
- and in any case it's nice to have them all customizeable not just the getting_started message. based on the presence of the `Messages` struct I presume this was always intended

how:
- add fields to `Messages` struct, named based on the hook they are associated with
- set sensible defaults for messages
- add messages to the hooks scripts
- splat configured messages into hooks scripts based on how it was done for the getting_started message

docs: updated the readme to document messages configuration

validation: tested new message configurations in a different project, `cargo test`