### PR TITLE
Delete .github/dependabot.yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "cargo"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    reviewers: ["NoRedInk/team-foxen"]


### PR DESCRIPTION
Dependabot is disabled on this repo, so this file does nothing. Removing it to prevent confusion.